### PR TITLE
keycloak: fix overrides key in compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ inc/
 /pm_to_blib
 /*.zip
 
-data/*
+data*/*
 *.tmp.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -172,8 +172,6 @@ RUN git config --global --add safe.directory /home/production/cxgn/sgn
 WORKDIR /home/production/cxgn
 
 # [REQUIRED]
-# Use the custom template
-COPY --chown=production:production docker/breedbase/sgn_local_template.conf sgn/sgn_local_template.conf
 # Use the interactive test file for interactive testing
 RUN cp /home/production/cxgn/treeimprovementbase/t/interactive.t /tmp/interactive.t
 # Set npm cache to the volume mount location

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Development mode will allow you to make changes to the application in real-time.
 
    > This will clone all the git repos that are needed for breedbase into a subdirectory called `cxgn/`. This directory will be mounted into the container during the compose step, but will still be accessible from the host for development work.
 
+1. **Build Docker Containers**
+
+    ```bash
+    docker compose up -f compose.development.yml build
+    ```
+
 1. **Deploy with docker compose**
 
     ```bash

--- a/docker/breedbase/sgn_local_template.conf
+++ b/docker/breedbase/sgn_local_template.conf
@@ -5,7 +5,7 @@ version_updated             2026-03-14T11:32:00-06:00
 
 #test
 dbhost breedbase_db
-dbname {PGDATABASE}
+dbname breedbase
 dbuser web_usr
 dbpass {WEB_USR_PASSWORD}
 

--- a/docker/breedbase/web.yml
+++ b/docker/breedbase/web.yml
@@ -95,7 +95,7 @@ services:
         bind:
           create_host_path: false
 
-      # Final config file (filed in template)
+      # Config file
       - type: bind
         source: $PWD/data/breedbase/sgn_local.conf
         target: /home/production/cxgn/sgn/sgn_local.conf
@@ -105,7 +105,7 @@ services:
       # Keep history of commands
       - type: bind
         source: $PWD/data/breedbase/bash_history
-        target: /home/production/.bash_history
+        target: /home/sgn/.bash_history
         bind:
           create_host_path: false
 

--- a/docker/breedbase/web_entrypoint.sh
+++ b/docker/breedbase/web_entrypoint.sh
@@ -48,6 +48,11 @@ start_sgn_server() {
     # Allow errors now to not stop the script
     set +e
 
+    echo "Updating config: sgn_local.conf"
+    cp sgn_local.conf /tmp/sgn_local.conf
+    sed -E "s|(dbpass ).*|\1  ${WEB_USR_PASSWORD}|g" /tmp/sgn_local.conf > sgn_local.conf
+    rm -f /tmp/sgn_local.conf
+
     if [ "$MODE" == "TESTING" ]; then
 
         # Expand out the args first, otherwise only the first arg is captured
@@ -65,6 +70,7 @@ start_sgn_server() {
         exit $exit_status
 
     elif [ "$MODE" == "DEVELOPMENT" ]; then
+
         /home/production/cxgn/sgn/bin/sgn_server.pl --fork -r -p 8080
 
     elif [ "$MODE" == "PRODUCTION" ]; then

--- a/docker/breedbase/web_entrypoint.sh
+++ b/docker/breedbase/web_entrypoint.sh
@@ -48,20 +48,6 @@ start_sgn_server() {
     # Allow errors now to not stop the script
     set +e
 
-    # Update config file with credentials
-    if [[ -e sgn_local_template.conf ]]; then
-        echo "Updating config: sgn_local.conf"
-        sed \
-            -e "s/{PGHOST}/$PGHOST/g" \
-            -e "s/{PGDATABASE}/$PGDATABASE/g" \
-            -e "s/{DOMAIN_NAME}/$DOMAIN_NAME/g" \
-            -e "s/{WEB_USR_PASSWORD}/$WEB_USR_PASSWORD/g" \
-            -e "s/{KC_HOSTNAME}/$KC_HOSTNAME/g" \
-            sgn_local_template.conf \
-            > sgn_local.conf
-        chown sgn:sgn sgn_local.conf
-    fi
-
     if [ "$MODE" == "TESTING" ]; then
 
         # Expand out the args first, otherwise only the first arg is captured

--- a/docker/breedbase/web_setup
+++ b/docker/breedbase/web_setup
@@ -266,9 +266,16 @@ initialize_javascript() {
     sudo -u $js_user npm config set engine-strict true
     echo "Install npm packages"
     sudo -u $js_user HOME=/tmp npm install --loglevel info
+    if [[ -f .git ]]; then
+        echo "Temporarily moving .git to .git-bak"
+        mv .git .git-bak
+    fi
     echo "Running webpack build..."
     sudo -u $js_user HOME=/tmp node_modules/.bin/webpack --config build.webpack.config.js
-    #sudo -u $js_user HOME=/tmp npm run build
+    if [[ -f .git-bak ]]; then
+        echo "Restoring .git from .git-bak"
+        mv .git-bak .git
+    fi
     cd -
 }
 

--- a/docker/breedbase/web_setup
+++ b/docker/breedbase/web_setup
@@ -80,6 +80,8 @@ initialize_user() {
 
     echo "Config user:   " $(getent passwd "$file_user")
     echo "Config group:  " $(getent group "$file_group")
+
+    chown $user_name:$user_name /home/$user_name
 }
 
 
@@ -260,7 +262,6 @@ initialize_javascript() {
     if [[ -d js/build ]]; then rm -rf js/build; fi
 
     cd js
-    js_user=$(ls -l package.json | sed -E 's/\s+/ /g' | cut -d ' ' -f 3)
 
     sudo -u $js_user npm config set engine-strict true
     echo "Install npm packages"

--- a/docker/keycloak/db.yml
+++ b/docker/keycloak/db.yml
@@ -10,7 +10,7 @@ services:
       TLS_DOMAIN: keycloak_db
     healthcheck:
       test: [ "CMD-SHELL", "psql -U postgres -q keycloak -c '\\dt'"]
-    volumes: !reset
+    volumes:
       - type: bind
         source: $PWD/data/keycloak_db/db
         target: /data/postgresql

--- a/docker/keycloak/db.yml
+++ b/docker/keycloak/db.yml
@@ -34,10 +34,3 @@ services:
         target: /data/log
         bind:
           create_host_path: false
-
-      - type: bind
-        source: ../postgres/pg_hba.conf
-        target: /etc/postgresql/pg_hba.conf
-        read_only: true
-        bind:
-          create_host_path: false

--- a/docker/keycloak/db.yml
+++ b/docker/keycloak/db.yml
@@ -10,7 +10,7 @@ services:
       TLS_DOMAIN: keycloak_db
     healthcheck:
       test: [ "CMD-SHELL", "psql -U postgres -q keycloak -c '\\dt'"]
-    volumes: !overrides
+    volumes: !reset
       - type: bind
         source: $PWD/data/keycloak_db/db
         target: /data/postgresql
@@ -32,5 +32,12 @@ services:
       - type: bind
         source: $PWD/data/keycloak_db/log
         target: /data/log
+        bind:
+          create_host_path: false
+
+      - type: bind
+        source: ../postgres/pg_hba.conf
+        target: /etc/postgresql/pg_hba.conf
+        read_only: true
         bind:
           create_host_path: false

--- a/docker/keycloak/db.yml
+++ b/docker/keycloak/db.yml
@@ -10,7 +10,7 @@ services:
       TLS_DOMAIN: keycloak_db
     healthcheck:
       test: [ "CMD-SHELL", "psql -U postgres -q keycloak -c '\\dt'"]
-    volumes: !override
+    volumes: !overrides
       - type: bind
         source: $PWD/data/keycloak_db/db
         target: /data/postgresql

--- a/setup
+++ b/setup
@@ -45,7 +45,21 @@ done
 mkdir -p data/breedbase/volume
 mkdir -p data/breedbase/downloads
 touch data/breedbase/bash_history
-touch data/breedbase/sgn_local.conf
+
+if [[ ! -e data/breedbase/sgn_local.conf ]]; then
+
+  if [[ $SITE_OVERLAY == "treeimprovementbase" ]]; then
+    template=cxgn/treeimprovementbase/sgn_local_template.conf
+  else
+    template=docker/breedbase/sgn_local_template.conf
+  fi
+
+  sed \
+    -e "s/{PROJECT_NAME}/$PROJECT_NAME/g" \
+    -e "s/{DOMAIN_NAME}/$DOMAIN_NAME/g" \
+    -e "s/{WEB_USR_PASSWORD}/$WEB_USR_PASSWORD/g" \
+    $template > data/breedbase/sgn_local.conf
+fi
 
 # keycloak web
 mkdir -p data/keycloak/export


### PR DESCRIPTION
- `keycloak`: Remove the `overrides` key which does nothing.
- `setup`: Conditional config file based on site overlay.
- `Dockerfile`: Remove custom `sgn_local_template.conf` file.
- `breedbase/web_setup`: Temporarily rename `.git` directory/file to `.git-bak` whil installing `npm` modules. If `breedbase_dockerfile` is a submodule of a parent repo, `npm` will error because we're missing the parent `.git` folder.
- `breedbase/web_entrypoint.sh`: Don't override `sgn_local.conf` with the template. Just update the `dbpass` config variable, (and main_production_site_url in PRODUCTION).
- `docker`: Mount bash history in `/home/sgn`.