### PR TITLE
Caddy: Add to development deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Link compose file
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Setup
         run: ./setup

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ mv data data_production
 
 1. **Access the applications via web browser.**
 
-    - Breedbase (Main Application): <http://localhost:8080>
-    - Keycloak Login (Single-Sign On/OIDC Testing): <http://localhost:9080/auth/realms/Breedbase/account>
-    - Keycloak Admin: http://localhost:9080/auth/admin/
+    - Breedbase (Main Application): <https://localhost>
+    - Keycloak Login (Single-Sign On/OIDC Testing): <https://localhost/auth/realms/Breedbase/account>
+    - Keycloak Admin: https://localhost/auth/admin/
 
     Login with the following credentials.
 
@@ -266,7 +266,7 @@ Tests can be run in `interactive` mode, where the same database and web server a
 1. **Start up all containers in interactive mode.**
 
     ```bash
-    D
+    ./run_test -i -s
     ```
 
 2. **Open a separate terminal to run the remaining commands.**

--- a/compose.development.yml
+++ b/compose.development.yml
@@ -21,8 +21,8 @@ services:
       file: docker/keycloak/web.yml
       service: keycloak
     environment:
-      KC_HOSTNAME:       http://localhost:9080/auth
-      KC_HOSTNAME_ADMIN: http://localhost:9080/auth
+      KC_HOSTNAME:       https://localhost/auth
+      KC_HOSTNAME_ADMIN: https://localhost/auth
 
   breedbase:
     extends:

--- a/compose.development.yml
+++ b/compose.development.yml
@@ -9,6 +9,13 @@ volumes:
 
 services:
 
+  caddy:
+    extends:
+      file: docker/caddy/caddy.yml
+      service: caddy
+    volumes:
+      - ./cxgn:/home/production/cxgn
+
   keycloak:
     extends:
       file: docker/keycloak/web.yml

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -14,6 +14,14 @@
 {$DOMAIN_NAME} {
 
 	# ---------------------------------------------------------------------
+	# Keycloak: Authentication
+
+	redir /auth /auth/
+	handle /auth/* {
+		reverse_proxy keycloak:9080
+	}
+
+	# ---------------------------------------------------------------------
 	# Jbrowse: Genome Browser and file server
 
 	redir /jbrowse /jbrowse/

--- a/docker/keycloak/realms/breedbase-realm.json
+++ b/docker/keycloak/realms/breedbase-realm.json
@@ -641,7 +641,8 @@
         "http://localhost:3010/authenticate/oidc/keycloak/callback",
         "http://localhost:8080/authenticate/oidc/keycloak/callback",
         "http://breedbase:3010/authenticate/oidc/keycloak/callback",
-        "http://breedbase:8080/authenticate/oidc/keycloak/callback"
+        "http://breedbase:8080/authenticate/oidc/keycloak/callback",
+        "https://localhost/authenticate/oidc/keycloak/callback"
       ],
       "webOrigins": [
         "http://test_breedbase:3010",
@@ -649,7 +650,8 @@
         "http://localhost:3010",
         "http://localhost:8080",
         "http://breedbase:3010",
-        "http://breedbase:8080"
+        "http://breedbase:8080",
+        "https://localhost"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
- Add caddy to the development deployment, to help with website performance that bogs down under static requests.
- Resolves #21 